### PR TITLE
Fix download path contain filename and add check if dedciated console available which vscode don't have and will cause exception

### DIFF
--- a/BAdownload/DownloadFiles.cs
+++ b/BAdownload/DownloadFiles.cs
@@ -71,8 +71,8 @@ internal class DownloadFiles
         foreach (var mediaResource in mediaResources)
         {
             string mediaUrl = $"{BaseUrl}/MediaResources/{mediaResource.Path}";
-            string destinationPath = Path.Combine(downloadDirectory, "MediaResources", Path.GetDirectoryName(mediaResource.Path) ?? string.Empty);
-            string destination = Path.Combine(destinationPath, mediaResource.FileName);
+            string destinationDirectory = Path.Combine(downloadDirectory, "MediaResources", Path.GetDirectoryName(mediaResource.Path) ?? string.Empty);
+            string destination = Path.Combine(destinationDirectory, mediaResource.FileName);
             
             if (File.Exists(destination))
             {
@@ -82,9 +82,9 @@ internal class DownloadFiles
                 continue;
             }
             // Create directory if it doesn't exist
-            if (!Directory.Exists(destinationPath))
+            if (!Directory.Exists(destinationDirectory))
             {
-                Directory.CreateDirectory(destinationPath);
+                Directory.CreateDirectory(destinationDirectory);
             }
     
             if (DownloadFile(mediaUrl, destination, mediaResource.Crc, httpClient, totalFiles, currentFile))

--- a/BAdownload/DownloadFiles.cs
+++ b/BAdownload/DownloadFiles.cs
@@ -1,4 +1,3 @@
-
 internal class DownloadFiles
 {
     private static string BaseUrl;
@@ -50,8 +49,12 @@ internal class DownloadFiles
             string destination = Path.Combine(downloadDirectory, "BundleFile", fileName);
             if (File.Exists(destination))
             {
-                Console.Write($"\rFile already exists locally: {destination}. Skipping download.".PadRight(Console.WindowWidth - 1));
-                Console.Out.Flush();
+                //considering someone may execute it in VS Code terminal,which is not a dedciated console
+                if (ConsoleIsAvailable())
+                {
+                    Console.Write($"\rFile already exists locally: {destination}. Skipping download.".PadRight(Console.WindowWidth - 1));
+                    Console.Out.Flush();
+                }
                 currentFile++;
                 continue;
             }
@@ -67,10 +70,10 @@ internal class DownloadFiles
 
         foreach (var mediaResource in mediaResources)
         {
-            
             string mediaUrl = $"{BaseUrl}/MediaResources/{mediaResource.Path}";
-            string destinationDirectory = Path.Combine(downloadDirectory, "MediaResources", mediaResource.Path);
-            string destination = Path.Combine(destinationDirectory, mediaResource.FileName);
+            string destinationPath = Path.Combine(downloadDirectory, "MediaResources", Path.GetDirectoryName(mediaResource.Path) ?? string.Empty);
+            string destination = Path.Combine(destinationPath, mediaResource.FileName);
+            
             if (File.Exists(destination))
             {
                 Console.Write($"\rFile already exists locally: {destination}. Skipping download.".PadRight(Console.WindowWidth - 1));
@@ -79,9 +82,9 @@ internal class DownloadFiles
                 continue;
             }
             // Create directory if it doesn't exist
-            if (!Directory.Exists(destinationDirectory))
+            if (!Directory.Exists(destinationPath))
             {
-                Directory.CreateDirectory(destinationDirectory);
+                Directory.CreateDirectory(destinationPath);
             }
     
             if (DownloadFile(mediaUrl, destination, mediaResource.Crc, httpClient, totalFiles, currentFile))
@@ -97,6 +100,7 @@ internal class DownloadFiles
             currentFile++;
         }
     }
+
     private static void DownloadTableBundle(List<(string Name, long Crc)> files, string downloadDirectory, HttpClient httpClient, int totalFiles)
     {
         int currentFile = 0;


### PR DESCRIPTION
This PR addresses two issues:

Fixes download path:

Handles lack of dedicated console: A check has been added to handle cases where a dedicated console is unavailable (e.g., VS Code). 